### PR TITLE
Follow relative symlinks

### DIFF
--- a/ts/lib/platforms/linux.ts
+++ b/ts/lib/platforms/linux.ts
@@ -39,7 +39,12 @@ export = function linuxFindJavaHome(cb: (homes: string[], executableExtension?: 
             // Trace path.
             try {
               while (1) {
-                javaPath = fs.readlinkSync(javaPath);
+                var newJavaPath = fs.readlinkSync(javaPath);
+                if (path.isAbsolute(newJavaPath)) {
+                  javaPath = newJavaPath;
+                } else {
+                  javaPath = path.resolve(path.dirname(javaPath), newJavaPath);
+                }
               }
             } catch (e) {
               // We reached the end of the link chain.


### PR DESCRIPTION
On Archlinux I get next chain of resolved symlinks:

1. /usr/bin/java
2. /usr/lib/jvm/default-runtime/bin/java
3. ../jre/bin/java
On step 3 link is not absolute any more and jvm detection fails.