### PR TITLE
Fix jdk detection

### DIFF
--- a/ts/test/index.ts
+++ b/ts/test/index.ts
@@ -27,6 +27,16 @@ describe('API Tests', function() {
       });
     });
   });
+  it('Finds JDK', async () => {
+    return new Promise<void>((resolve, reject) => {
+      LocateJavaHome({ mustBeJDK: true }, (err, found?: Array<IJavaHomeInfo>) => {
+        assertEqual(!err, true, `An error occurred while finding JAVA_HOME: ${err}`);
+        assertEqual(found!.length > 0, true, `No JAVA_HOME found`);
+        javaHomes = found!;
+        resolve();
+      });
+    });
+  });
   it('Found Java installations match data reported by LocateJavaHome', () => {
     for (const javaHome of javaHomes) {
       const java = javaHome.executables.java;

--- a/ts/test/index.ts
+++ b/ts/test/index.ts
@@ -32,7 +32,6 @@ describe('API Tests', function() {
       LocateJavaHome({ mustBeJDK: true }, (err, found?: Array<IJavaHomeInfo>) => {
         assertEqual(!err, true, `An error occurred while finding JAVA_HOME: ${err}`);
         assertEqual(found!.length > 0, true, `No JAVA_HOME found`);
-        javaHomes = found!;
         resolve();
       });
     });

--- a/ts/test/index.ts
+++ b/ts/test/index.ts
@@ -80,8 +80,6 @@ describe(`CLI Tests`, () => {
     const output = spawnSync('node', [LJH_BIN]);
     const lines = output.stdout.toString().trim().split("\n");
     assertEqual(lines.length, javaHomes.length + 1, `Should print all found JAVA_HOMES`);
-    const firstJavaHome = javaHomes[0];
-    const firstJavaHomeLines = lines.filter((l) => l.indexOf(firstJavaHome.path) !== -1);
-    assertEqual(firstJavaHomeLines.length, 1, `There should be one line of output for each JAVA_HOME found.`);
+    assertEqual(lines.length, new Set(lines).size, `There should be one line of output for each JAVA_HOME found.`);
   });
 });


### PR DESCRIPTION
- Fixed JDK detection for case when `java` and `javac` are in different locations.
- Added test for JDK detection
- Fixed test for unique paths of java home locations (`/usr/lib/jvm/default` and `/usr/lib/jvm/default-runtime/jre` were considered identical)