### PR TITLE
Adds JAVA_HOME as an option on Darwin and Windows

### DIFF
--- a/ts/lib/platforms/darwin.ts
+++ b/ts/lib/platforms/darwin.ts
@@ -18,6 +18,13 @@ export default function macFindJavaHome(cb: (homes: string[], executableExtensio
     // Map to paths.
     // TODO: We assume that quotes cannot be in the paths.
     installations = installations.map((install) => install.slice(install.lastIndexOf('"') + 1).trim());
+
+    // Option 2: Is JAVA_HOME defined?
+    // (NOTE: locate_java_home will prune redundancies.)
+    if (process.env.JAVA_HOME) {
+      installations.push(process.env.JAVA_HOME!);
+    }
+
     cb(installations);
   });
 }

--- a/ts/lib/platforms/win32.ts
+++ b/ts/lib/platforms/win32.ts
@@ -6,7 +6,7 @@ interface IKeyInfo {
 }
 
 /**
- * Find Java on Windows by checking registry keys.
+ * Find Java on Windows by checking registry keys and PATH
  */
 export default function windowsFindJavaHome(cb: (homes: string[], executableExtension?: string) => void): void {
   // Windows: JDK path is in either of the following registry keys:
@@ -24,6 +24,13 @@ export default function windowsFindJavaHome(cb: (homes: string[], executableExte
   ];
 
   const discoveredJavaHomes: string[] = [];
+
+  // Option 1: Is JAVA_HOME defined?
+  // (NOTE: locate_java_home will prune redundancies.)
+  if (process.env.JAVA_HOME) {
+    discoveredJavaHomes.push(process.env.JAVA_HOME!);
+  }
+
   eachSeries(keysToCheck, (key: string, asyncCb: (err?: Error) => void) => {
     getRegistryKey(key, (err?: Error | null, values?: IKeyInfo) => {
       if (!err) {


### PR DESCRIPTION
Fixes #9 as well as establishes compatibility with the [setup-java action for GitHub Workflows](https://github.com/actions/setup-java):
This action installs the desired java version on Ubuntu, macOS, and Windows. `java --version` is available on all 3 platforms after installation. However, `locate-java-home` is unable to find it on Windows. This gets addressed by this PR