### PR TITLE
Handle more than one space in update-java-alternatives row delimiters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "locate-java-home",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Locates JAVA_HOME on any platform, and can differentiate between different versions.",
   "main": "js/es5/index.js",
   "module": "js/es6/index.js",

--- a/ts/lib/platforms/linux.ts
+++ b/ts/lib/platforms/linux.ts
@@ -17,7 +17,7 @@ export default function linuxFindJavaHome(cb: (homes: string[], executableExtens
       const alts = stdout.toString().trim().split('\n');
       for (const alt of alts) {
         // "java-1.7.0-openjdk-amd64 1071 /usr/lib/jvm/java-1.7.0-openjdk-amd64"
-        discoveredJavaHomes.push(alt.split(' ')[2]);
+        discoveredJavaHomes.push(alt.split(/[\s]+/)[2]);
       }
     }
     // Option 2: Is JAVA_HOME defined?


### PR DESCRIPTION
Hey, thanks for this sharp tool.  I'm launching Java like a boss because of you!

My linux install of update-java-alternatives on Ubuntu 20.04 does some pretty formating for columns of data.  It's output looks like this:

```
java-1.11.0-openjdk-amd64      1111       /usr/lib/jvm/java-1.11.0-openjdk-amd64
java-1.8.0-openjdk-amd64       1081       /usr/lib/jvm/java-1.8.0-openjdk-amd64
```

Those unexpected extra spaces did not parse properly for the linux platform implementation and caused no JVM's to be detected from the output of `update-java-alternatives -l`.

This fix does a regex to parse one or more spaces between columns instead of a single space.